### PR TITLE
Ics systems rework

### DIFF
--- a/src/main/mal/ics/ControlServer.mal
+++ b/src/main/mal/ics/ControlServer.mal
@@ -7,8 +7,6 @@ category IcsControlResources{
       // Override view related attack steps (Impact) becase they are not relevant to this asset
       | manipulationOfView @Override
 
-      | denialOfView @Override
-
       | lossOfView @Override
       }
 

--- a/src/main/mal/ics/Controller.mal
+++ b/src/main/mal/ics/Controller.mal
@@ -4,9 +4,10 @@ category IcsControlResources{
         user info: "Controllers utilize a programmable logic-based application that provides scanning and writing of data to and from the IO interface modules and communicates with the control system network via various communications methods, including serial and network communications."
         developer info: "https://collaborate.mitre.org/attackics/index.php/Field_Controller/RTU/PLC/IED"
       {
-      # physicalLock
-        user info: "A controller can have a phyisical lock in place that disallows modifications on the programmable logic, thus making it invulnerable to manipulations."
-        ->  attemptManipulation
+        # physicalLock
+          user info: "A controller can have a physical lock in place that disallows modifications on the programmable logic, thus making it invulnerable to manipulations."
+          ->  manipulate
+
       }
 
 }

--- a/src/main/mal/ics/Controller.mal
+++ b/src/main/mal/ics/Controller.mal
@@ -4,13 +4,6 @@ category IcsControlResources{
         user info: "Controllers utilize a programmable logic-based application that provides scanning and writing of data to and from the IO interface modules and communicates with the control system network via various communications methods, including serial and network communications."
         developer info: "https://collaborate.mitre.org/attackics/index.php/Field_Controller/RTU/PLC/IED"
       {
-      // Override view related attack steps (Impact) becase they are not relevant to this asset
-      | manipulationOfView @Override
-
-      | denialOfView @Override
-
-      | lossOfView @Override
-
       # physicalLock
         user info: "A controller can have a phyisical lock in place that disallows modifications on the programmable logic, thus making it invulnerable to manipulations."
         ->  attemptManipulation

--- a/src/main/mal/ics/DataHistorian.mal
+++ b/src/main/mal/ics/DataHistorian.mal
@@ -5,8 +5,6 @@ category IcsInterfaceResources{
         developer info: "https://collaborate.mitre.org/attackics/index.php/Data_Historian"
       {
       // Override control related attack steps (Impact) because they are not relevant to this asset
-      | denialOfControl @Override
-
       | manipulationOfControl @Override
 
       | lossOfControl @Override

--- a/src/main/mal/ics/EngineeringWorkstation.mal
+++ b/src/main/mal/ics/EngineeringWorkstation.mal
@@ -4,7 +4,17 @@ category IcsControlResources{
         user info: "The engineering workstation is usually a high-end very reliable computing platform designed for configuration, maintenance and diagnostics of the control system applications and other control system equipment."
         developer info: "https://collaborate.mitre.org/attackics/index.php/Engineering_Workstation"
       {
+        | fullAccess @Override
+          +> reprogramControllers
 
+        | reprogramControllers
+          user info: "Reprogram all of the controllers that the engineering station has access to."
+          ->  programmableControllers.attemptManipulation
       }
 
+}
+
+associations {
+  EngineeringWorkstation [programmingWorkstations]  * <-- programLogic     --> *   [programmableControllers] Controller
+      user info: "Engineering workstations are responsible for programming the logic on controllers used both in the industrial control processes and the safety systems."
 }

--- a/src/main/mal/ics/IOServer.mal
+++ b/src/main/mal/ics/IOServer.mal
@@ -7,8 +7,6 @@ category IcsInterfaceResources{
       // Override view related attack steps (Impact) becase they are not relevant to this asset
       | manipulationOfView @Override
 
-      | denialOfView @Override
-
       | lossOfView @Override
       }
 

--- a/src/main/mal/ics/SIS.mal
+++ b/src/main/mal/ics/SIS.mal
@@ -4,7 +4,8 @@ category IcsControlResources{
         user info: "A safety instrumented system (SIS) takes automated action to keep a plant in a safe state, or to put it into a safe state, when abnormal conditions are present."
         developer info: "https://collaborate.mitre.org/attackics/index.php/Safety_Instrumented_System/Protection_Relay"
       {
-
+        | shutdown @Override
+            +> safeguardedSystem.lossOfSafety
       }
 
 }

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -40,7 +40,9 @@ category ComputeResources {
       | fullAccess @Override
         +>  lossOfSafety,
             lossOfControl,
-            lossOfAvailability
+            lossOfAvailability,
+            manipulationOfView,
+            manipulationOfControl
 
       & replicationThroughRemovableMedia [HardAndUncertain]
         user info: "An adversary can get access by copying malware to removable media which is inserted into the control systems environment."

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -259,7 +259,7 @@ category ComputeResources {
       | normalOperation
         user info: "The state where the operational component is operating normally or seems to be operating normally (but is undetectably manipulated within the safety limits)."
         developer info: "I am not sure if we need this. But I keep it to add one more vector that we can model! (Sotirios)"
-        ->  attemptManipulation
+        ->  attemptCovertManipulation
 
       | restrictedOperation {I,A}
         user info: "When the operational component is compromised, the operation of it is affected."
@@ -272,8 +272,15 @@ category ComputeResources {
             lossOfView,
             hostSystem[IcsSystem].lossOfAvailability
 
-      & attemptManipulation [HardAndUncertain]
+      & attemptCovertManipulation [HardAndUncertain]
         user info: "If an application is operating normally it could even be the case that it is elaborately manipulated by an adversary."
+        ->  attemptManipulation
+
+      | attemptManipulation
+        user info: "The adversary is actively manipulating the system outside of normal operating parameters."
+        ->  manipulate
+
+      & manipulate @hidden
         ->  manipulationOfControl,
             manipulationOfView
 

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -197,7 +197,7 @@ category ComputeResources {
 
       | propagateCriticalLossOfView @hidden
         user info: "Propagate loss of view to the parent system if any of the critical subsystems experience a loss of view"
-        -> manipulationOfView
+        -> lossOfView
 
       | propagateCriticalManipulationOfControl @hidden
         user info: "Propagate manipulation of control to the parent system if any of the critical subsystems experience a manipulation of control"

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -94,6 +94,11 @@ category ComputeResources {
       | deny @Override {A}
         +>  lossOfAvailability
 
+      !E sisConnected @hidden
+        developer info: "If the ICS system is not connected to an SIS the safety mechanisms should be disabled"
+        <-  sis
+        ->  safetyMechanismsOffline
+
       // Impact attack steps
       | attemptPreemptiveShutdown @hidden
         user info: "Intermediate attack step for modelling the possibility of detecting a disruption(loss/denial of Control/View) and preemptively shutting down the system in order to prevent damage."
@@ -129,7 +134,9 @@ category ComputeResources {
 
       | shutdown {A}
         user info: "Shutdown the system. Can be initiated by the attacker intentionally to disrupt the industrial process or unintentionally by tampering with system and accidentally triggering the safety shutdown procedures. If the staff detect anomalous behaviour and they can decide to preemptively shut the system down to prevent potential damage."
-        ->  lossOfAvailability
+        ->  lossOfAvailability,
+            criticalParentSystem.propagateCriticalShutdown,
+            redundantParentSystem.propagateRedundantShutdown
 
       & damageToProperty {I, A}
         user info: "Adversaries may cause damage and destruction of property to infrastructure, equipment, and the surrounding environment when attacking control systems."
@@ -140,16 +147,57 @@ category ComputeResources {
       | lossOfControl {I}
         user info: "Adversaries may seek to achieve a sustained loss of control or a runaway condition in which operators cannot issue any commands even if the malicious interference has subsided."
         developer info: "MITRE ATT&CK ICS T827."
-        ->  attemptPreemptiveShutdown
+        ->  attemptPreemptiveShutdown,
+            criticalParentSystem.propagateCriticalLossOfControl,
+            redundantParentSystem.propagateRedundantLossOfControl
 
       | lossOfAvailability {A}
         user info: "Adversaries may attempt to disrupt essential components or systems to prevent owner and operator from delivering products or services."
         developer info: "MITRE ATT&CK ICS T826."
-        ->  lossOfProductivityAndRevenue
+        ->  lossOfProductivityAndRevenue,
+            criticalParentSystem.propagateCriticalLossOfAvailability,
+            redundantParentSystem.propagateRedundantLossOfAvailability
 
       | lossOfProductivityAndRevenue
         user info: "Adversaries may cause loss of productivity and revenue through disruption and even damage to the availability and integrity of control system operations, devices, and related processes."
         developer info: "MITRE ATT&CK ICS T828."
+        ->  criticalParentSystem.propagateCriticalLossOfProductivityAndRevenue,
+            redundantParentSystem.propagateRedundantLossOfProductivityAndRevenue
+
+      // Propagate subsystems attack steps
+      // Critical subsystems
+      | propagateCriticalShutdown @hidden
+        user info: "Propagate shutdown to the parent system if any of the critical subsystems experience a shutdown"
+        -> shutdown
+
+      | propagateCriticalLossOfControl @hidden
+        user info: "Propagate loss of control to the parent system if any of the critical subsystems experience a loss of control"
+        -> lossOfControl
+
+      | propagateCriticalLossOfAvailability @hidden
+        user info: "Propagate loss of availability to the parent system if any of the critical subsystems experience a loss of availability"
+        -> lossOfAvailability
+
+      | propagateCriticalLossOfProductivityAndRevenue @hidden
+        user info: "Propagate loss of productivity and revenue to the parent system if any of the critical subsystems experience a loss of productivity and revenue"
+        -> lossOfProductivityAndRevenue
+
+      // Redundant subsystems
+      & propagateRedundantShutdown @hidden
+        user info: "Propagate shutdown to the parent system if all of the redundant subsystems experience a shutdown"
+        -> shutdown
+
+      & propagateRedundantLossOfControl @hidden
+        user info: "Propagate loss of control to the parent system if all of the redundant subsystems experience a loss of control"
+        -> lossOfControl
+
+      & propagateRedundantLossOfAvailability @hidden
+        user info: "Propagate loss of availability to the parent system if all of the redundant subsystems experience a loss of availability"
+        -> lossOfAvailability
+
+      & propagateRedundantLossOfProductivityAndRevenue @hidden
+        user info: "Propagate loss of productivity and revenue to the parent system if all of the redundant subsystems experience a loss of productivity and revenue"
+        -> lossOfProductivityAndRevenue
 
     }
 
@@ -391,22 +439,30 @@ category ComputeResources {
   }
 
 associations {
-  IcsApplication [signalSourceApp]    * <-- AppTransmittedSignal  --> *     [transmittedSignal] Signal
+  IcsSystem [criticalParentSystem]  0..1 <-- CriticalSubsystem     --> *     [criticalSubsystems]     IcsSystem
+      user info: "IcsSystems can be nested, a disruption in any of the critical subsystems will be triggered in the parent system as well."
+  IcsSystem [redundantParentSystem] 0..1 <-- RedundantSubsystem    --> *     [redundantSubsystems]    IcsSystem
+      user info: "IcsSystems can be nested, a disruption will propagate to the parent system only if all of the redundant subsystems are affected by it."
+  IcsSystem    [safeguardedSystem]  0..1 <-- SafetyControls        --> 0..1  [sis]            SIS
+      user info: "An IcsSystem can have an SIS assigned to it to ensure that it is operating within safe parameters and act if it is not."
+  IcsApplication [signalSourceApp]     * <-- AppTransmittedSignal  --> *     [transmittedSignal] Signal
       user info: "Any ics application can transmit a signal."
-  IcsApplication [signalDestApp]      * <-- AppReceivedSignal     --> *     [receivedSignal] Signal
+  IcsApplication [signalDestApp]       * <-- AppReceivedSignal     --> *     [receivedSignal] Signal
       user info: "Any ics application can receive/consume a signal."
-  Sensor         [signalSensor]       * <-- SensorSignal          --> *     [signal]         Signal
+  Sensor         [signalSensor]        * <-- SensorSignal          --> *     [signal]         Signal
       user info: "Any sensor can be associated with a signal over which it can send data."
-  Actuator       [signalActuator]     * <-- ActuatorSignal        --> *     [signal]         Signal
+  Sensor         [sysSensor]           * <-- SensorBelongsTo       --> *     [system]         IcsSystem
+      user info: "A sensor can be associated with a system where it measures a specific parameter."
+  Actuator       [signalActuator]      * <-- ActuatorSignal        --> *     [signal]         Signal
       user info: "An actuator can be associated with a signal from which it receives data/commands."
-  Actuator       [sysActuator]        * <-- AcuatorBelongsTo      --> *     [system]         IcsSystem
+  Actuator       [sysActuator]         * <-- AcuatorBelongsTo      --> *     [system]         IcsSystem
       user info: "An actuator can be associated with a system on which it actuates."
-  IcsApplication [synchronizedApp]    * <-- SynchronizationModule --> 0..1  [synchronizationModule]    SynchronizationModule
+  IcsApplication [synchronizedApp]     * <-- SynchronizationModule --> 0..1  [synchronizationModule]    SynchronizationModule
       user info: "Any ics application can have one synchronization module to provide synchronization on the signals sent."
-  Signal         [encryptedSignal]    * <-- EncryptionCredentials --> 0..1  [encryptCreds]   Credentials
+  Signal         [encryptedSignal]     * <-- EncryptionCredentials --> 0..1  [encryptCreds]   Credentials
       user info: "Encrypted signal can be associated with the relevant encryption credentials."
-  Signal         [containerSignal]    * <-- DataContainment       --> *     [containedData]  Data
+  Signal         [containerSignal]     * <-- DataContainment       --> *     [containedData]  Data
       user info: "Data can be contained inside a signal."
-  Signal         [containerSignal]    * <-- InfoContainment       --> *     [information]    Information
+  Signal         [containerSignal]     * <-- InfoContainment       --> *     [information]    Information
       user info: "A signal can contain information."
 }

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -109,7 +109,7 @@ category ComputeResources {
         ->  shutdown
 
       | attemptUnsafeState @hidden [Bernoulli(0.1)]
-        developer info: "This attack step models the possibility that a naturally occurring unsafe state is reached if there is a loss/denial of control or view. The specific probability should be researched more and maybe defined by the modeller. WARNING: The current implementation is incorrect. The unsafe state should only be reached if the preemptive shutdown did not occur."
+        developer info: "This attack step models the possibility that a naturally occurring unsafe state is reached if there is a loss/denial of control or view. The specific probability should be researched more and maybe defined by the modeller."
         ->  unsafeState
 
       | unsafeState @hidden

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -95,24 +95,57 @@ category ComputeResources {
         +>  lossOfAvailability
 
       // Impact attack steps
+      | attemptPreemptiveShutdown @hidden
+        user info: "Intermediate attack step for modelling the possibility of detecting a disruption(loss/denial of Control/View) and preemptively shutting down the system in order to prevent damage."
+        ->  attemptShutdown,
+            attemptUnsafeState
+
+      | attemptPreemptiveShutdownOnSafetyLoss @hidden
+        user info: "Intermediate attack step for modelling the possibility of detecting a disruption(loss of Safety) and preemptively shutting down the system because of concerns. The loss of safety alone does not trigger either a shutdown or generate an unsafe state as control and view are expected to maintain the system operating within normal parameters."
+        ->  attemptShutdown
+
+      | attemptShutdown @hidden [Bernoulli(0.1)]
+        developer info: "This is the actual preemptive shutdown operation. The specific probability should be researched more and maybe defined by the modeller."
+        ->  shutdown
+
+      | attemptUnsafeState @hidden [Bernoulli(0.1)]
+        developer info: "This attack step models the possibility that a naturally occurring unsafe state is reached if there is a loss/denial of control or view. The specific probability should be researched more and maybe defined by the modeller. WARNING: The current implementation is incorrect. The unsafe state should only be reached if the preemptive shutdown did not occur."
+        ->  unsafeState
+
+      | unsafeState @hidden
+        developer info: "The system can only be damaged if it has reached an unsafe operating state. If the safety mechanisms are still functional the system will shutdown without taking damage, otherwise the damage done to the system will bring it down."
+        ->  damageToProperty,
+            shutdown
+
       | lossOfSafety
         user info: "Adversaries may cause loss of safety whether on purpose or as a consequence of actions taken to accomplish an operation."
         developer info: "MITRE ATT&CK ICS T880."
+        ->  safetyMechanismsOffline,
+            attemptPreemptiveShutdownOnSafetyLoss
+
+      | safetyMechanismsOffline @hidden
+        user info: "Physical assets should only be damaged if the safety mechanisms fail to shutdown the system to prevent damage"
         ->  damageToProperty
 
-      | damageToProperty {A}
+      | shutdown {A}
+        user info: "Shutdown the system. Can be initiated by the attacker intentionally to disrupt the industrial process or unintentionally by tampering with system and accidentally triggering the safety shutdown procedures. If the staff detect anomalous behaviour and they can decide to preemptively shut the system down to prevent potential damage."
+        ->  lossOfAvailability
+
+      & damageToProperty {I, A}
         user info: "Adversaries may cause damage and destruction of property to infrastructure, equipment, and the surrounding environment when attacking control systems."
         developer info: "MITRE ATT&CK ICS T879."
-        ->  lossOfProductivityAndRevenue
+        ->  shutdown,
+            lossOfProductivityAndRevenue
 
       | lossOfControl {I}
         user info: "Adversaries may seek to achieve a sustained loss of control or a runaway condition in which operators cannot issue any commands even if the malicious interference has subsided."
         developer info: "MITRE ATT&CK ICS T827."
-        ->  damageToProperty
+        ->  attemptPreemptiveShutdown
 
       | lossOfAvailability {A}
         user info: "Adversaries may attempt to disrupt essential components or systems to prevent owner and operator from delivering products or services."
         developer info: "MITRE ATT&CK ICS T826."
+        ->  lossOfProductivityAndRevenue
 
       | lossOfProductivityAndRevenue
         user info: "Adversaries may cause loss of productivity and revenue through disruption and even damage to the availability and integrity of control system operations, devices, and related processes."
@@ -146,7 +179,7 @@ category ComputeResources {
             denialOfView,
             lossOfControl,
             lossOfView,
-            lossOfAvailability
+            hostSystem[IcsSystem].lossOfAvailability
 
       & attemptManipulation [HardAndUncertain]
         user info: "If an applicaiton is operating normaly it could even be the case that it is elaborately manipulated by an adversary."
@@ -158,54 +191,47 @@ category ComputeResources {
         user info: "Adversaries may cause a denial of control to temporarily prevent operators and engineers from interacting with process controls."
         developer info: "MITRE ATT&CK ICS T813."
         ->  restrictedOperation,
-            transmittedSignal.blockSignal
+            transmittedSignal.blockSignal,
+            hostSystem[IcsSystem].attemptPreemptiveShutdown
 
       | manipulationOfControl {I,A}
         user info: "Adversaries may manipulate control systems devices or possibly leverage their own, to communicate with and command physical control processes."
         developer info: "MITRE ATT&CK ICS T831."
         ->  restrictedOperation,
-            transmittedSignal.manipulateSignal
+            transmittedSignal.manipulateSignal,
+            hostSystem[IcsSystem].unsafeState
 
       | lossOfControl {I}
         user info: "Adversaries may seek to achieve a sustained loss of control or a runaway condition in which operators cannot issue any commands even if the malicious interference has subsided."
         developer info: "MITRE ATT&CK ICS T827."
-        ->  damageToProperty
+        ->  hostSystem[IcsSystem].attemptPreemptiveShutdown
 
       // View related attack steps (Impact)
       | manipulationOfView {I}
         user info: "Adversaries may attempt to manipulate the information reported back to operators or controllers."
         developer info: "MITRE ATT&CK ICS T832."
         ->  restrictedOperation,
-            transmittedSignal.manipulateSignal
+            transmittedSignal.manipulateSignal,
+            hostSystem[IcsSystem].unsafeState
 
       | denialOfView {I}
         user info: "Adversaries may cause a denial of view in attempt to disrupt and prevent operator oversight on the status of an ICS environment."
         developer info: "MITRE ATT&CK ICS T815."
         ->  restrictedOperation,
-            transmittedSignal.blockSignal
+            transmittedSignal.blockSignal,
+            hostSystem[IcsSystem].attemptPreemptiveShutdown
 
       | lossOfView {I}
         user info: "Adversaries may cause a sustained or permanent loss of view where the ICS equipment will require local, hands-on operator intervention."
         developer info: "MITRE ATT&CK ICS T829."
-        ->  restrictedOperation
+        ->  restrictedOperation,
+            hostSystem[IcsSystem].attemptPreemptiveShutdown
 
       // Other types of Impact
       | theftOfOperationalInformation {C}
         user info: "Adversaries may steal operational information on a production environment as a direct mission outcome for personal gain or to inform future operations."
         developer info: "MITRE ATT&CK ICS T882."
 
-      | damageToProperty {A}
-        user info: "Adversaries may cause damage and destruction of property to infrastructure, equipment, and the surrounding environment when attacking control systems."
-        developer info: "MITRE ATT&CK ICS T879."
-        ->  lossOfProductivityAndRevenue
-
-      | lossOfAvailability {A}
-        user info: "Adversaries may attempt to disrupt essential components or systems to prevent owner and operator from delivering products or services."
-        developer info: "MITRE ATT&CK ICS T826."
-
-      | lossOfProductivityAndRevenue
-        user info: "Adversaries may cause loss of productivity and revenue through disruption and even damage to the availability and integrity of control system operations, devices, and related processes."
-        developer info: "MITRE ATT&CK ICS T828."
     }
 
     asset Sensor

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -45,7 +45,7 @@ category ComputeResources {
       & replicationThroughRemovableMedia [HardAndUncertain]
         user info: "An adversary can get access by copying malware to removable media which is inserted into the control systems environment."
         developer info: "MITRE ATT&CK ICS T847."
-        modeler info: "The probability fucntion and its value is just an estimation!"
+        modeler info: "The probability function and its value is just an estimation!"
         ->  bypassAccessControl
 
       # disallowRemovableMedia
@@ -164,7 +164,7 @@ category ComputeResources {
             attemptManipulation
 
       | normalOperation
-        user info: "The state where the operational component is operating normaly or seems to be operating normaly (but is undetectably manipulated within the safety limits)."
+        user info: "The state where the operational component is operating normally or seems to be operating normally (but is undetectably manipulated within the safety limits)."
         developer info: "I am not sure if we need this. But I keep it to add one more vector that we can model! (Sotirios)"
         ->  attemptManipulation
 
@@ -182,7 +182,7 @@ category ComputeResources {
             hostSystem[IcsSystem].lossOfAvailability
 
       & attemptManipulation [HardAndUncertain]
-        user info: "If an applicaiton is operating normaly it could even be the case that it is elaborately manipulated by an adversary."
+        user info: "If an application is operating normally it could even be the case that it is elaborately manipulated by an adversary."
         ->  manipulationOfControl,
             manipulationOfView
 

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -101,7 +101,7 @@ category ComputeResources {
 
       // Impact attack steps
       | attemptPreemptiveShutdown @hidden
-        user info: "Intermediate attack step for modelling the possibility of detecting a disruption(loss/denial of Control/View) and preemptively shutting down the system in order to prevent damage."
+        user info: "Intermediate attack step for modelling the possibility of detecting a disruption(loss of Control/View) and preemptively shutting down the system in order to prevent damage."
         ->  attemptShutdown,
             attemptUnsafeState
 
@@ -114,7 +114,7 @@ category ComputeResources {
         ->  shutdown
 
       | attemptUnsafeState @hidden [Bernoulli(0.1)]
-        developer info: "This attack step models the possibility that a naturally occurring unsafe state is reached if there is a loss/denial of control or view. The specific probability should be researched more and maybe defined by the modeller."
+        developer info: "This attack step models the possibility that a naturally occurring unsafe state is reached if there is a loss of control or view. The specific probability should be researched more and maybe defined by the modeller."
         ->  unsafeState
 
       | unsafeState @hidden
@@ -144,12 +144,19 @@ category ComputeResources {
         ->  shutdown,
             lossOfProductivityAndRevenue
 
-      | lossOfControl {I}
+      | lossOfControl {A}
         user info: "Adversaries may seek to achieve a sustained loss of control or a runaway condition in which operators cannot issue any commands even if the malicious interference has subsided."
         developer info: "MITRE ATT&CK ICS T827."
         ->  attemptPreemptiveShutdown,
             criticalParentSystem.propagateCriticalLossOfControl,
             redundantParentSystem.propagateRedundantLossOfControl
+
+      | lossOfView {A}
+        user info: "Adversaries may cause a sustained or permanent loss of view where the ICS equipment will require local, hands-on operator intervention."
+        developer info: "MITRE ATT&CK ICS T829."
+        ->  attemptPreemptiveShutdown,
+            criticalParentSystem.propagateCriticalLossOfView,
+            redundantParentSystem.propagateRedundantLossOfView
 
       | lossOfAvailability {A}
         user info: "Adversaries may attempt to disrupt essential components or systems to prevent owner and operator from delivering products or services."
@@ -164,6 +171,20 @@ category ComputeResources {
         ->  criticalParentSystem.propagateCriticalLossOfProductivityAndRevenue,
             redundantParentSystem.propagateRedundantLossOfProductivityAndRevenue
 
+      | manipulationOfControl {I, A}
+        user info: "Adversaries may manipulate control systems devices or possibly leverage their own, to communicate with and command physical control processes."
+        developer info: "MITRE ATT&CK ICS T831."
+        ->  unsafeState,
+            criticalParentSystem.propagateCriticalManipulationOfControl,
+            redundantParentSystem.propagateRedundantManipulationOfControl
+
+      | manipulationOfView {I, A}
+        user info: "Adversaries may attempt to manipulate the information reported back to operators or controllers."
+        developer info: "MITRE ATT&CK ICS T832."
+        ->  unsafeState,
+            criticalParentSystem.propagateCriticalManipulationOfView,
+            redundantParentSystem.propagateRedundantManipulationOfView
+
       // Propagate subsystems attack steps
       // Critical subsystems
       | propagateCriticalShutdown @hidden
@@ -173,6 +194,18 @@ category ComputeResources {
       | propagateCriticalLossOfControl @hidden
         user info: "Propagate loss of control to the parent system if any of the critical subsystems experience a loss of control"
         -> lossOfControl
+
+      | propagateCriticalLossOfView @hidden
+        user info: "Propagate loss of view to the parent system if any of the critical subsystems experience a loss of view"
+        -> manipulationOfView
+
+      | propagateCriticalManipulationOfControl @hidden
+        user info: "Propagate manipulation of control to the parent system if any of the critical subsystems experience a manipulation of control"
+        -> manipulationOfControl
+
+      | propagateCriticalManipulationOfView @hidden
+        user info: "Propagate manipulation of view to the parent system if any of the critical subsystems experience a manipulation of view"
+        -> manipulationOfView
 
       | propagateCriticalLossOfAvailability @hidden
         user info: "Propagate loss of availability to the parent system if any of the critical subsystems experience a loss of availability"
@@ -190,6 +223,18 @@ category ComputeResources {
       & propagateRedundantLossOfControl @hidden
         user info: "Propagate loss of control to the parent system if all of the redundant subsystems experience a loss of control"
         -> lossOfControl
+
+      & propagateRedundantLossOfView @hidden
+        user info: "Propagate loss of view to the parent system if all of the redundant subsystems experience a loss of view"
+        -> lossOfView
+
+      & propagateRedundantManipulationOfControl @hidden
+        user info: "Propagate manipulation of control to the parent system if all of the redundant subsystems experience a manipulation of control"
+        -> manipulationOfControl
+
+      & propagateRedundantManipulationOfView @hidden
+        user info: "Propagate manipulation of view to the parent system if all of the redundant subsystems experience a manipulation of view"
+        -> manipulationOfView
 
       & propagateRedundantLossOfAvailability @hidden
         user info: "Propagate loss of availability to the parent system if all of the redundant subsystems experience a loss of availability"
@@ -223,9 +268,7 @@ category ComputeResources {
         +>  theftOfOperationalInformation
 
       | deny @Override {A}
-        +>  denialOfControl,
-            denialOfView,
-            lossOfControl,
+        +>  lossOfControl,
             lossOfView,
             hostSystem[IcsSystem].lossOfAvailability
 
@@ -235,41 +278,29 @@ category ComputeResources {
             manipulationOfView
 
       // Control related attack steps (Impact)
-      | denialOfControl {A}
-        user info: "Adversaries may cause a denial of control to temporarily prevent operators and engineers from interacting with process controls."
-        developer info: "MITRE ATT&CK ICS T813."
-        ->  restrictedOperation,
-            transmittedSignal.blockSignal,
-            hostSystem[IcsSystem].attemptPreemptiveShutdown
-
-      | manipulationOfControl {I,A}
+      | manipulationOfControl {I, A}
         user info: "Adversaries may manipulate control systems devices or possibly leverage their own, to communicate with and command physical control processes."
         developer info: "MITRE ATT&CK ICS T831."
         ->  restrictedOperation,
             transmittedSignal.manipulateSignal,
             hostSystem[IcsSystem].unsafeState
 
-      | lossOfControl {I}
+      | lossOfControl {A}
         user info: "Adversaries may seek to achieve a sustained loss of control or a runaway condition in which operators cannot issue any commands even if the malicious interference has subsided."
         developer info: "MITRE ATT&CK ICS T827."
-        ->  hostSystem[IcsSystem].attemptPreemptiveShutdown
+        ->  restrictedOperation,
+            transmittedSignal.blockSignal,
+            hostSystem[IcsSystem].attemptPreemptiveShutdown
 
       // View related attack steps (Impact)
-      | manipulationOfView {I}
+      | manipulationOfView {I, A}
         user info: "Adversaries may attempt to manipulate the information reported back to operators or controllers."
         developer info: "MITRE ATT&CK ICS T832."
         ->  restrictedOperation,
             transmittedSignal.manipulateSignal,
             hostSystem[IcsSystem].unsafeState
 
-      | denialOfView {I}
-        user info: "Adversaries may cause a denial of view in attempt to disrupt and prevent operator oversight on the status of an ICS environment."
-        developer info: "MITRE ATT&CK ICS T815."
-        ->  restrictedOperation,
-            transmittedSignal.blockSignal,
-            hostSystem[IcsSystem].attemptPreemptiveShutdown
-
-      | lossOfView {I}
+      | lossOfView {A}
         user info: "Adversaries may cause a sustained or permanent loss of view where the ICS equipment will require local, hands-on operator intervention."
         developer info: "MITRE ATT&CK ICS T829."
         ->  restrictedOperation,
@@ -289,16 +320,18 @@ category ComputeResources {
       | physicalAccess
         user info: "Attacker has physical access on the location where the sensor is physically deployed."
         ->  signal.manipulateSignal,
-            signal.blockSignal
+            signal.blockSignal,
+            system.lossOfView,
+            system.manipulationOfView
     }
 
     asset Actuator
       user info: "An object that consumes data (from a signal) but may not have any associated software or host."
     {
-      | manipulate {I}
+      | manipulate {I, A}
         user info: "If the signal that is consumed by this actuator is manipulated then the actuator is also manipulated."
-        developer info: "This will lead to loss of control on the associated system."
-        ->  system.lossOfControl
+        developer info: "This will lead to manipulation of control on the associated system."
+        ->  system.manipulationOfControl
 
       | block {A}
         user info: "If the signal that is consumed by this actuator is blocked then the actuator is also blocked."
@@ -324,8 +357,8 @@ category ComputeResources {
             synchronizedApp.manipulationOfView
 
       | stopClock
-        ->  synchronizedApp.denialOfControl,
-            synchronizedApp.denialOfView
+        ->  synchronizedApp.lossOfControl,
+            synchronizedApp.lossOfView
     }
 
   }
@@ -402,10 +435,10 @@ category ComputeResources {
           ->  containedData.attemptWrite,
               attemptDelete
 
-        & delete {I,A}
+        & delete {I, A}
           user info: "The attacker can delete the data."
           ->  containedData.attemptDelete
-        
+
         // STPA-SafeSec related attack steps (Those four need to be differentiated somehow)
         | applyControlSignalTooEarly
           ->  signalDestApp.manipulationOfControl
@@ -426,15 +459,14 @@ category ComputeResources {
               applyControlSignalTooEarly,
               applyControlSignalNotLongEnough,
               signalActuator.manipulate,
+              signalSourceApp.manipulationOfControl,
               signalDestApp.manipulationOfView
 
         | blockSignal
           user info: "When an attacker block a signal from being sent/received."
           ->  signalActuator.block,
-              signalDestApp.denialOfControl,
-              signalDestApp.lossOfControl,
-              signalDestApp.lossOfView,
-              signalDestApp.denialOfView
+              signalSourceApp.lossOfControl,
+              signalDestApp.lossOfView
     }
   }
 


### PR DESCRIPTION
Added **redundant** and **critical subsystems** to **IcsSystem**. The two sets propagate failures to their parent **IcsSystem**.

A failure is propagated upwards if <ins>any</ins> of the systems in the **critical subsystems** list has experienced a failure. On the other hand, a failure is propagated upwards if <ins>all</ins> of the systems in the **redundant subsystems** list has experienced a failure.

Also, a **safeguard** one-to-one relationship between an **IcsSystem** and an **SIS** was introduced. An **IcsSystem** that does not have an **SIS** safeguarding it has its **safety mechanisms disabled**. If the **SIS**  shuts down it will trigger a **Loss of Safety** on the associated **IcsSystem**.

Because the **SIS** asset inherits the **IcsSystem** asset it can have **critical** and **redundant subsystems** as well in order to model more complex mechanisms.