### PR TITLE
Introduce IcsData/IcsControlData analogous to how signals are used.

### DIFF
--- a/src/main/mal/ics/EngineeringWorkstation.mal
+++ b/src/main/mal/ics/EngineeringWorkstation.mal
@@ -9,6 +9,7 @@ category IcsControlResources{
 
         | reprogramControllers
           user info: "Reprogram all of the controllers that the engineering station has access to."
+          modeler info: "This is meant to simulate situations where how the controllers are programmed is unknown, irrelevant, or over a temporary connection. Otherwise the Network and ConnectionRule assets should be used to propagate the attack."
           ->  programmableControllers.attemptManipulation
       }
 

--- a/src/main/mal/ics/SIS.mal
+++ b/src/main/mal/ics/SIS.mal
@@ -1,11 +1,18 @@
 category IcsControlResources{
 
-    asset SIS extends IcsSystem 
+    asset SIS extends IcsSystem
         user info: "A safety instrumented system (SIS) takes automated action to keep a plant in a safe state, or to put it into a safe state, when abnormal conditions are present."
         developer info: "https://collaborate.mitre.org/attackics/index.php/Safety_Instrumented_System/Protection_Relay"
       {
         | shutdown @Override
             +> safeguardedSystem.lossOfSafety
+
+        # notDisabled @Override [Enabled]
+          developer info: "The probability that a particular SIS is not actually present."
+          modeler info: "The use cases for this are removing the SIS safeguarding an IcsSystem and removing redundant SIS subsystems."
+          -> safeguardedSystem.safetyMechanismsOffline,
+             triggerPropagateRedundantShutdown
+
       }
 
 }

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -291,7 +291,7 @@ category ComputeResources {
         user info: "Adversaries may manipulate control systems devices or possibly leverage their own, to communicate with and command physical control processes."
         developer info: "MITRE ATT&CK ICS T831."
         ->  restrictedOperation,
-            transmittedSignal.manipulateSignal,
+            transmittedControlSignal.manipulateSignal,
             transmittedControlData.attemptWrite,
             hostSystem[IcsSystem].manipulationOfControl,
             hostSystem[IcsSystem].unsafeState
@@ -300,7 +300,7 @@ category ComputeResources {
         user info: "Adversaries may seek to achieve a sustained loss of control or a runaway condition in which operators cannot issue any commands even if the malicious interference has subsided."
         developer info: "MITRE ATT&CK ICS T827."
         ->  restrictedOperation,
-            transmittedSignal.blockSignal,
+            transmittedControlSignal.blockSignal,
             transmittedControlData.attemptDeny,
             hostSystem[IcsSystem].lossOfControl,
             hostSystem[IcsSystem].attemptPreemptiveShutdown
@@ -477,12 +477,12 @@ category ComputeResources {
         | manipulateSignal @Override
           user info: "When an attacker sends a false or manipulated signal."
           ->  signalActuator.manipulate,
-              signalDestApp.manipulationOfControl
+              controlSignalDestApp.manipulationOfControl
 
         | blockSignal @Override
           user info: "When an attacker blocks a signal from being sent/received."
           ->  signalActuator.block,
-              signalDestApp.lossOfControl
+              controlSignalDestApp.lossOfControl
     }
 
     asset IcsData extends Data
@@ -526,42 +526,46 @@ category ComputeResources {
   }
 
 associations {
-  IcsSystem [criticalParentSystem]  0..1 <-- CriticalSubsystem     --> *     [criticalSubsystems]     IcsSystem
+  IcsSystem [criticalParentSystem]     0..1 <-- CriticalSubsystem           --> *     [criticalSubsystems]     IcsSystem
       user info: "IcsSystems can be nested, a disruption in any of the critical subsystems will be triggered in the parent system as well."
-  IcsSystem [redundantParentSystem] 0..1 <-- RedundantSubsystem    --> *     [redundantSubsystems]    IcsSystem
+  IcsSystem [redundantParentSystem]    0..1 <-- RedundantSubsystem          --> *     [redundantSubsystems]    IcsSystem
       user info: "IcsSystems can be nested, a disruption will propagate to the parent system only if all of the redundant subsystems are affected by it."
-  IcsSystem    [safeguardedSystem]  0..1 <-- SafetyControls        --> 0..1  [sis]            SIS
+  IcsSystem    [safeguardedSystem]     0..1 <-- SafetyControls              --> 0..1  [sis]            SIS
       user info: "An IcsSystem can have an SIS assigned to it to ensure that it is operating within safe parameters and act if it is not."
-  IcsApplication [signalSourceApp]     * <-- AppTransmittedSignal  --> *     [transmittedSignal] Signal
+  IcsApplication [signalSourceApp]        * <-- AppTransmittedSignal        --> *     [transmittedSignal] Signal
       user info: "Any ics application can transmit a signal."
-  IcsApplication [signalDestApp]       * <-- AppReceivedSignal     --> *     [receivedSignal] Signal
+  IcsApplication [signalDestApp]          * <-- AppReceivedSignal           --> *     [receivedSignal] Signal
       user info: "Any ics application can receive/consume a signal."
-  IcsApplication [dataSourceApp]       * <-- AppTransmittedData    --> *     [transmittedData] IcsData
+  IcsApplication [controlSignalSourceApp] * <-- AppTransmittedControlSignal --> *     [transmittedControlSignal] ControlSignal
+      user info: "Any ics application can transmit a signal."
+  IcsApplication [controlSignalDestApp]   * <-- AppReceivedControlSignal    --> *     [receivedControlSignal] ControlSignal
+      user info: "Any ics application can receive/consume a signal."
+  IcsApplication [dataSourceApp]         * <-- AppTransmittedData           --> *     [transmittedData] IcsData
       user info: "Any ics application can transmit data."
-  IcsApplication [dataDestApp]         * <-- AppReceivedData       --> *     [receivedData]   IcsData
+  IcsApplication [dataDestApp]           * <-- AppReceivedData              --> *     [receivedData]   IcsData
       user info: "Any ics application can receive/consume data."
-  IcsApplication [dataSourceApp]       * <-- AppTransmittedData    --> *     [transmittedControlData] IcsControlData
+  IcsApplication [dataSourceApp]         * <-- AppTransmittedData           --> *     [transmittedControlData] IcsControlData
       user info: "Any ics application can transmit control data."
-  IcsApplication [dataDestApp]         * <-- AppReceivedData       --> *     [receivedControlData]   IcsControlData
+  IcsApplication [dataDestApp]           * <-- AppReceivedData              --> *     [receivedControlData]   IcsControlData
       user info: "Any ics application can receive/consume control data."
-  Sensor         [signalSensor]        * <-- SensorSignal          --> *     [signal]         Signal
+  Sensor         [signalSensor]          * <-- SensorSignal                 --> *     [signal]         Signal
       user info: "Any sensor can be associated with a signal over which it can send data."
-  Sensor         [dataSensor]          * <-- SensorData            --> *     [data]           IcsData
+  Sensor         [dataSensor]            * <-- SensorData                   --> *     [data]           IcsData
       user info: "Any sensor can be associated with data it sends."
-  Sensor         [sysSensor]           * <-- SensorBelongsTo       --> *     [system]         IcsSystem
+  Sensor         [sysSensor]             * <-- SensorBelongsTo              --> *     [system]         IcsSystem
       user info: "A sensor can be associated with a system where it measures a specific parameter."
-  Actuator       [signalActuator]      * <-- ActuatorSignal        --> *     [signal]         ControlSignal
+  Actuator       [signalActuator]        * <-- ActuatorSignal               --> *     [signal]         ControlSignal
       user info: "An actuator can be associated with a signal from which it receives commands."
-  Actuator       [dataActuator]        * <-- ActuatorData          --> *     [data]           IcsControlData
+  Actuator       [dataActuator]          * <-- ActuatorData                 --> *     [data]           IcsControlData
       user info: "An actuator can be associated with data that contain commands."
-  Actuator       [sysActuator]         * <-- AcuatorBelongsTo      --> *     [system]         IcsSystem
+  Actuator       [sysActuator]           * <-- AcuatorBelongsTo             --> *     [system]         IcsSystem
       user info: "An actuator can be associated with a system on which it actuates."
-  IcsApplication [synchronizedApp]     * <-- SynchronizationModule --> 0..1  [synchronizationModule]    SynchronizationModule
+  IcsApplication [synchronizedApp]       * <-- SynchronizationModule        --> 0..1  [synchronizationModule]    SynchronizationModule
       user info: "Any ics application can have one synchronization module to provide synchronization on the signals sent."
-  Signal         [encryptedSignal]     * <-- EncryptionCredentials --> 0..1  [encryptCreds]   Credentials
+  Signal         [encryptedSignal]       * <-- EncryptionCredentials        --> 0..1  [encryptCreds]   Credentials
       user info: "Encrypted signal can be associated with the relevant encryption credentials."
-  Signal         [containerSignal]     * <-- DataContainment       --> *     [containedData]  Data
+  Signal         [containerSignal]       * <-- DataContainment              --> *     [containedData]  Data
       user info: "Data can be contained inside a signal."
-  Signal         [containerSignal]     * <-- InfoContainment       --> *     [information]    Information
+  Signal         [containerSignal]       * <-- InfoContainment              --> *     [information]    Information
       user info: "A signal can contain information."
 }

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -292,6 +292,8 @@ category ComputeResources {
         developer info: "MITRE ATT&CK ICS T831."
         ->  restrictedOperation,
             transmittedSignal.manipulateSignal,
+            transmittedControlData.attemptWrite,
+            hostSystem[IcsSystem].manipulationOfControl,
             hostSystem[IcsSystem].unsafeState
 
       | lossOfControl {A}
@@ -299,6 +301,8 @@ category ComputeResources {
         developer info: "MITRE ATT&CK ICS T827."
         ->  restrictedOperation,
             transmittedSignal.blockSignal,
+            transmittedControlData.attemptDeny,
+            hostSystem[IcsSystem].lossOfControl,
             hostSystem[IcsSystem].attemptPreemptiveShutdown
 
       // View related attack steps (Impact)
@@ -307,12 +311,17 @@ category ComputeResources {
         developer info: "MITRE ATT&CK ICS T832."
         ->  restrictedOperation,
             transmittedSignal.manipulateSignal,
+            transmittedData.attemptWrite,
+            hostSystem[IcsSystem].manipulationOfView,
             hostSystem[IcsSystem].unsafeState
 
       | lossOfView {A}
         user info: "Adversaries may cause a sustained or permanent loss of view where the ICS equipment will require local, hands-on operator intervention."
         developer info: "MITRE ATT&CK ICS T829."
         ->  restrictedOperation,
+            transmittedSignal.blockSignal,
+            transmittedData.attemptDeny,
+            hostSystem[IcsSystem].lossOfView,
             hostSystem[IcsSystem].attemptPreemptiveShutdown
 
       // Other types of Impact
@@ -330,6 +339,8 @@ category ComputeResources {
         user info: "Attacker has physical access on the location where the sensor is physically deployed."
         ->  signal.manipulateSignal,
             signal.blockSignal,
+            data.attemptWrite,
+            data.attemptDeny,
             system.lossOfView,
             system.manipulationOfView
     }
@@ -340,12 +351,14 @@ category ComputeResources {
       | manipulate {I, A}
         user info: "If the signal that is consumed by this actuator is manipulated then the actuator is also manipulated."
         developer info: "This will lead to manipulation of control on the associated system."
-        ->  system.manipulationOfControl
+        ->  data.attemptWrite,
+            system.manipulationOfControl
 
       | block {A}
         user info: "If the signal that is consumed by this actuator is blocked then the actuator is also blocked."
         developer info: "This will lead to loss of control and loss of availability on the associated system."
-        ->  system.lossOfControl,
+        ->  data.attemptDeny,
+            system.lossOfControl,
             system.lossOfAvailability
     }
 
@@ -375,8 +388,8 @@ category ComputeResources {
   category DataResources {
 
     asset Signal
-      user info: "A signal represents a command that is sent between two assets but the medium over which is transmitted is not relevant to the model."
-      modeler info: "In the case where data or information are transmitted over a known medium, the Data asset and the DataInTransit association should be used instead."
+      user info: "A signal represents information that is sent between two assets but the medium over which is transmitted is not relevant to the model."
+      modeler info: "In the case where data or information are transmitted over a known medium, the IcsData asset and the DataInTransit association should be used instead."
       developer info: "The basic attack steps of this asset were inspired by the attack steps of the data asset in coreLang."
     {
       // Basic attack steps below
@@ -467,15 +480,69 @@ category ComputeResources {
               applyControlSignalTooLate,
               applyControlSignalTooEarly,
               applyControlSignalNotLongEnough,
-              signalActuator.manipulate,
-              signalSourceApp.manipulationOfControl,
               signalDestApp.manipulationOfView
 
         | blockSignal
-          user info: "When an attacker block a signal from being sent/received."
+          user info: "When an attacker blocks a signal from being sent/received."
+          ->  signalDestApp.lossOfView
+    }
+
+    asset ControlSignal extends Signal
+      user info: "A ControlSignal represents control commands are sent between two assets but the medium over which is transmitted is not relevant to the model."
+      modeler info: "In the case where control commands are transmitted over a known medium, the IcsControlData asset and the DataInTransit association should be used instead."
+    {
+        | manipulateSignal @Override
+          user info: "When an attacker sends a false or manipulated signal."
+          ->  applyControlSignalTooLong,
+              applyControlSignalTooLate,
+              applyControlSignalTooEarly,
+              applyControlSignalNotLongEnough,
+              signalActuator.manipulate,
+              signalDestApp.manipulationOfControl
+
+        | blockSignal @Override
+          user info: "When an attacker blocks a signal from being sent/received."
           ->  signalActuator.block,
-              signalSourceApp.lossOfControl,
-              signalDestApp.lossOfView
+              signalDestApp.lossOfControl
+    }
+
+    asset IcsData extends Data
+      user info: "An ICS Data extends coreLang's Data with OT attack vectors and directionality for non-control information."
+      modeler info: "This data represents the non-control information sent over the OT network"
+    {
+        & write  @Override {I}
+          user info: "Modifying the data leads to a manipulation of view on the destination(s) and a manipulation of control on the source(s)"
+          +>  dataDestApp.manipulationOfView
+
+
+        & delete @Override {I, A}
+          user info: "Deleting the data leads to a loss of view on the destination(s) and a loss of control on the source(s)"
+          +>  dataDestApp.lossOfView
+
+        & deny @Override {A}
+          user info: "Denying access to the data leads to a loss of view on the destination(s) and a loss of control on the source(s)"
+          +>  dataDestApp.lossOfView
+    }
+
+    asset IcsControlData extends Data
+      user info: "An ICS Control Data extends coreLang's Data with OT attack vectors and directionality for control information."
+      modeler info: "This data represents the control information sent over the OT network"
+    {
+        & write  @Override {I}
+          user info: "Modifying the data leads to a manipulation of view on the destination(s) and a manipulation of control on the source(s)"
+          +>  dataActuator.manipulate,
+              dataDestApp.manipulationOfControl
+
+
+        & delete @Override {I, A}
+          user info: "Deleting the data leads to a loss of view on the destination(s) and a loss of control on the source(s)"
+          +>  dataActuator.block,
+              dataDestApp.lossOfControl
+
+        & deny @Override {A}
+          user info: "Denying access to the data leads to a loss of view on the destination(s) and a loss of control on the source(s)"
+          +>  dataActuator.block,
+              dataDestApp.lossOfControl
     }
   }
 
@@ -490,12 +557,24 @@ associations {
       user info: "Any ics application can transmit a signal."
   IcsApplication [signalDestApp]       * <-- AppReceivedSignal     --> *     [receivedSignal] Signal
       user info: "Any ics application can receive/consume a signal."
+  IcsApplication [dataSourceApp]       * <-- AppTransmittedData    --> *     [transmittedData] IcsData
+      user info: "Any ics application can transmit data."
+  IcsApplication [dataDestApp]         * <-- AppReceivedData       --> *     [receivedData]   IcsData
+      user info: "Any ics application can receive/consume data."
+  IcsApplication [dataSourceApp]       * <-- AppTransmittedData    --> *     [transmittedControlData] IcsControlData
+      user info: "Any ics application can transmit control data."
+  IcsApplication [dataDestApp]         * <-- AppReceivedData       --> *     [receivedControlData]   IcsControlData
+      user info: "Any ics application can receive/consume control data."
   Sensor         [signalSensor]        * <-- SensorSignal          --> *     [signal]         Signal
       user info: "Any sensor can be associated with a signal over which it can send data."
+  Sensor         [dataSensor]          * <-- SensorData            --> *     [data]           IcsData
+      user info: "Any sensor can be associated with data it sends."
   Sensor         [sysSensor]           * <-- SensorBelongsTo       --> *     [system]         IcsSystem
       user info: "A sensor can be associated with a system where it measures a specific parameter."
-  Actuator       [signalActuator]      * <-- ActuatorSignal        --> *     [signal]         Signal
-      user info: "An actuator can be associated with a signal from which it receives data/commands."
+  Actuator       [signalActuator]      * <-- ActuatorSignal        --> *     [signal]         ControlSignal
+      user info: "An actuator can be associated with a signal from which it receives commands."
+  Actuator       [dataActuator]        * <-- ActuatorData          --> *     [data]           IcsControlData
+      user info: "An actuator can be associated with data that contain commands."
   Actuator       [sysActuator]         * <-- AcuatorBelongsTo      --> *     [system]         IcsSystem
       user info: "An actuator can be associated with a system on which it actuates."
   IcsApplication [synchronizedApp]     * <-- SynchronizationModule --> 0..1  [synchronizationModule]    SynchronizationModule

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -351,15 +351,12 @@ category ComputeResources {
       | manipulate {I, A}
         user info: "If the signal that is consumed by this actuator is manipulated then the actuator is also manipulated."
         developer info: "This will lead to manipulation of control on the associated system."
-        ->  data.attemptWrite,
-            system.manipulationOfControl
+        ->  system.manipulationOfControl
 
       | block {A}
         user info: "If the signal that is consumed by this actuator is blocked then the actuator is also blocked."
         developer info: "This will lead to loss of control and loss of availability on the associated system."
-        ->  data.attemptDeny,
-            system.lossOfControl,
-            system.lossOfAvailability
+        ->  system.lossOfControl
     }
 
     asset SynchronizationModule

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -461,26 +461,9 @@ category ComputeResources {
           user info: "The attacker can delete the data."
           ->  containedData.attemptDelete
 
-        // STPA-SafeSec related attack steps (Those four need to be differentiated somehow)
-        | applyControlSignalTooEarly
-          ->  signalDestApp.manipulationOfControl
-
-        | applyControlSignalTooLate
-          ->  signalDestApp.manipulationOfControl
-
-        | applyControlSignalTooLong
-          ->  signalDestApp.manipulationOfControl
-
-        | applyControlSignalNotLongEnough
-          ->  signalDestApp.manipulationOfControl
-
         | manipulateSignal
           user info: "When an attacker sends a false or manipulated signal."
-          ->  applyControlSignalTooLong,
-              applyControlSignalTooLate,
-              applyControlSignalTooEarly,
-              applyControlSignalNotLongEnough,
-              signalDestApp.manipulationOfView
+          ->  signalDestApp.manipulationOfView
 
         | blockSignal
           user info: "When an attacker blocks a signal from being sent/received."
@@ -493,11 +476,7 @@ category ComputeResources {
     {
         | manipulateSignal @Override
           user info: "When an attacker sends a false or manipulated signal."
-          ->  applyControlSignalTooLong,
-              applyControlSignalTooLate,
-              applyControlSignalTooEarly,
-              applyControlSignalNotLongEnough,
-              signalActuator.manipulate,
+          ->  signalActuator.manipulate,
               signalDestApp.manipulationOfControl
 
         | blockSignal @Override

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -138,7 +138,11 @@ category ComputeResources {
         user info: "Shutdown the system. Can be initiated by the attacker intentionally to disrupt the industrial process or unintentionally by tampering with system and accidentally triggering the safety shutdown procedures. If the staff detect anomalous behaviour and they can decide to preemptively shut the system down to prevent potential damage."
         ->  lossOfAvailability,
             criticalParentSystem.propagateCriticalShutdown,
-            redundantParentSystem.propagateRedundantShutdown
+            triggerPropagateRedundantShutdown
+
+      | triggerPropagateRedundantShutdown @hidden
+        developer info: "This is an intermediary step required for the situation where SIS redundant subsystems are disabled."
+        ->  redundantParentSystem.propagateRedundantShutdown
 
       & damageToProperty {I, A}
         user info: "Adversaries may cause damage and destruction of property to infrastructure, equipment, and the surrounding environment when attacking control systems."
@@ -245,6 +249,16 @@ category ComputeResources {
       & propagateRedundantLossOfProductivityAndRevenue @hidden
         user info: "Propagate loss of productivity and revenue to the parent system if all of the redundant subsystems experience a loss of productivity and revenue"
         -> lossOfProductivityAndRevenue
+
+      # notDisabled [Enabled]
+        developer info: "The probability that a particular IcsSystem is not actually present."
+        modeler info: "The use case for this is removing some of the IcsSystems used to provide redundancy."
+        -> lossOfControl,
+           lossOfView,
+           lossOfAvailability,
+           lossOfProductivityAndRevenue,
+           manipulationOfControl,
+           manipulationOfView
 
     }
 

--- a/src/main/mal/icsLang.mal
+++ b/src/main/mal/icsLang.mal
@@ -258,7 +258,8 @@ category ComputeResources {
            lossOfAvailability,
            lossOfProductivityAndRevenue,
            manipulationOfControl,
-           manipulationOfView
+           manipulationOfView,
+           shutdown
 
     }
 

--- a/src/test/java/org/mal_lang/icslang/test/ActuatorTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/ActuatorTest.java
@@ -1,0 +1,44 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class ActuatorTest extends IcsLangTest {
+    private static class ActuatorTestModel {
+        public final Actuator actuator = new Actuator("actuator");
+        public final IcsSystem icsSystem = new IcsSystem("icsSystem");
+
+        public ActuatorTestModel() {
+            actuator.addSystem(icsSystem);
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    @Test
+    public void testActuatorManipulate() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new ActuatorTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.actuator.manipulate);
+        attacker.attack();
+
+        model.icsSystem.manipulationOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testActuatorBlock() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new ActuatorTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.actuator.block);
+        attacker.attack();
+
+        model.icsSystem.lossOfControl.assertCompromisedInstantaneously();
+    }
+}

--- a/src/test/java/org/mal_lang/icslang/test/ControlSignalTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/ControlSignalTest.java
@@ -1,0 +1,50 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class ControlSignalTest extends IcsLangTest {
+    private static class ControlSignalTestModel {
+        public final ControlSignal controlSignal = new ControlSignal("controlSignal");
+        public final Actuator actuator = new Actuator("actuator");
+        public final IcsApplication destApp = new IcsApplication("destApp");
+
+        public ControlSignalTestModel() {
+            controlSignal.addControlSignalDestApp(destApp);
+            controlSignal.addSignalActuator(actuator);
+        }
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+  }
+
+
+    @Test
+    public void testManipulateControlSignal() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new ControlSignalTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.controlSignal.manipulateSignal);
+        attacker.attack();
+
+        model.actuator.manipulate.assertCompromisedInstantaneously();
+        model.destApp.manipulationOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testBlockControlSignal() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new ControlSignalTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.controlSignal.blockSignal);
+        attacker.attack();
+
+        model.actuator.block.assertCompromisedInstantaneously();
+        model.destApp.lossOfControl.assertCompromisedInstantaneously();
+    }
+
+
+}

--- a/src/test/java/org/mal_lang/icslang/test/ControllerTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/ControllerTest.java
@@ -1,0 +1,31 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class ControllerTest extends IcsLangTest {
+    private static class ControllerTestModel {
+        public final Controller controller = new
+            Controller("controller", false, true);
+
+        public ControllerTestModel() {
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    @Test
+    public void testControllerAttemptManipulateWithPhysicalLock() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new ControllerTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.controller.attemptManipulation);
+        attacker.attack();
+
+        model.controller.manipulate.assertUncompromised();
+    }
+}

--- a/src/test/java/org/mal_lang/icslang/test/EngineeringWorkstationTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/EngineeringWorkstationTest.java
@@ -1,0 +1,45 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class EngineeringWorkstationTest extends IcsLangTest {
+    private static class EngineeringWorkstationTestModel {
+        public final EngineeringWorkstation engineeringWorkstation = new
+            EngineeringWorkstation("engineeringWorkstation");
+        public final Controller controller = new Controller("controller");
+
+        public EngineeringWorkstationTestModel() {
+            engineeringWorkstation.addProgrammableControllers(controller);
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    @Test
+    public void testEngineeringWorkstationFullAccess() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new EngineeringWorkstationTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.engineeringWorkstation.fullAccess);
+        attacker.attack();
+
+        model.engineeringWorkstation.reprogramControllers.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testEngineeringWorkstationReprogramControllers() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new EngineeringWorkstationTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.engineeringWorkstation.fullAccess);
+        attacker.attack();
+
+        model.controller.attemptManipulation.assertCompromisedInstantaneously();
+    }
+}

--- a/src/test/java/org/mal_lang/icslang/test/IcsApplicationTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/IcsApplicationTest.java
@@ -1,0 +1,192 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class IcsApplicationTest extends IcsLangTest {
+    private static class IcsApplicationTestModel {
+        public final IcsApplication icsApplication = new
+            IcsApplication("icsApplication");
+
+        public IcsApplicationTestModel() {
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    private static class IcsApplicationAndSystemTestModel {
+        public final IcsApplication icsApplication = new
+            IcsApplication("icsApplication");
+        public final IcsSystem icsSystem = new
+            IcsSystem("icsSystem");
+
+        public IcsApplicationAndSystemTestModel() {
+            icsSystem.addSysExecutedApps(icsApplication);
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    private static class IcsApplicationComplexTestModel {
+        public final IcsApplication icsApplication = new
+            IcsApplication("icsApplication");
+        public final IcsSystem icsSystem = new
+            IcsSystem("icsSystem");
+        public final Signal signal = new Signal("signal");
+        public final ControlSignal controlSignal = new
+            ControlSignal("controlSignal");
+        public final IcsData icsData = new
+            IcsData("icsData");
+        public final IcsControlData icsControlData = new
+            IcsControlData("icsControlData");
+
+        public IcsApplicationComplexTestModel() {
+            icsSystem.addSysExecutedApps(icsApplication);
+            icsApplication.addTransmittedSignal(signal);
+            icsApplication.addTransmittedControlSignal(controlSignal);
+            icsApplication.addTransmittedData(icsData);
+            icsApplication.addTransmittedControlData(icsControlData);
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    @Test
+    public void testIcsApplicationSpecificAccess() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsApplicationTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsApplication.specificAccess);
+        attacker.attack();
+
+        model.icsApplication.normalOperation.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsApplicationFullAccess() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsApplicationTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsApplication.fullAccess);
+        attacker.attack();
+
+        model.icsApplication.normalOperation.assertCompromisedInstantaneously();
+        model.icsApplication.attemptManipulation.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsApplicationRead() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsApplicationTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsApplication.read);
+        attacker.attack();
+
+        model.icsApplication.theftOfOperationalInformation.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsApplicationDeny() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsApplicationAndSystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsApplication.deny);
+        attacker.attack();
+
+        model.icsApplication.lossOfControl.assertCompromisedInstantaneously();
+        model.icsApplication.lossOfView.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfAvailability.assertCompromisedInstantaneously();
+        model.icsApplication.manipulationOfControl.assertUncompromised();
+        model.icsApplication.manipulationOfView.assertUncompromised();
+    }
+
+    @Test
+    public void testIcsApplicationManipulate() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsApplicationTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsApplication.manipulate);
+        attacker.attack();
+
+        model.icsApplication.manipulationOfControl.assertCompromisedInstantaneously();
+        model.icsApplication.manipulationOfView.assertCompromisedInstantaneously();
+        model.icsApplication.lossOfControl.assertUncompromised();
+        model.icsApplication.lossOfView.assertUncompromised();
+    }
+
+    @Test
+    public void testIcsApplicationManipulationOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsApplicationComplexTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsApplication.manipulationOfControl);
+        attacker.attack();
+
+        model.icsApplication.restrictedOperation.assertCompromisedInstantaneously();
+        model.controlSignal.manipulateSignal.assertCompromisedInstantaneously();
+        model.icsControlData.attemptWrite.assertCompromisedInstantaneously();
+        model.icsSystem.manipulationOfControl.assertCompromisedInstantaneously();
+        model.icsSystem.unsafeState.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsApplicationLossOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsApplicationComplexTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsApplication.lossOfControl);
+        attacker.attack();
+
+        model.icsApplication.restrictedOperation.assertCompromisedInstantaneously();
+        model.controlSignal.blockSignal.assertCompromisedInstantaneously();
+        model.icsControlData.attemptDeny.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfControl.assertCompromisedInstantaneously();
+        model.icsSystem.attemptPreemptiveShutdown.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsApplicationManipulationOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsApplicationComplexTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsApplication.manipulationOfView);
+        attacker.attack();
+
+        model.icsApplication.restrictedOperation.assertCompromisedInstantaneously();
+        model.signal.manipulateSignal.assertCompromisedInstantaneously();
+        model.icsData.attemptWrite.assertCompromisedInstantaneously();
+        model.icsSystem.manipulationOfView.assertCompromisedInstantaneously();
+        model.icsSystem.unsafeState.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsApplicationLossOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsApplicationComplexTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsApplication.lossOfView);
+        attacker.attack();
+
+        model.icsApplication.restrictedOperation.assertCompromisedInstantaneously();
+        model.signal.blockSignal.assertCompromisedInstantaneously();
+        model.icsData.attemptDeny.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfView.assertCompromisedInstantaneously();
+        model.icsSystem.attemptPreemptiveShutdown.assertCompromisedInstantaneously();
+    }
+}

--- a/src/test/java/org/mal_lang/icslang/test/IcsControlDataTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/IcsControlDataTest.java
@@ -1,0 +1,62 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class IcsControlDataTest extends IcsLangTest {
+    private static class IcsControlDataTestModel {
+        public final IcsControlData icsControlData = new IcsControlData("icsControlData");
+        public final Actuator actuator = new Actuator("actuator");
+        public final IcsApplication destApp = new IcsApplication("destApp");
+
+        public IcsControlDataTestModel() {
+            icsControlData.addDataDestApp(destApp);
+            icsControlData.addDataActuator(actuator);
+        }
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+  }
+
+
+    @Test
+    public void testIcsControlDataWrite() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsControlDataTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsControlData.write);
+        attacker.attack();
+
+        model.actuator.manipulate.assertCompromisedInstantaneously();
+        model.destApp.manipulationOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsControlDataDelete() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsControlDataTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsControlData.delete);
+        attacker.attack();
+
+        model.actuator.block.assertCompromisedInstantaneously();
+        model.destApp.lossOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsControlDataDeny() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsControlDataTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsControlData.deny);
+        attacker.attack();
+
+        model.actuator.block.assertCompromisedInstantaneously();
+        model.destApp.lossOfControl.assertCompromisedInstantaneously();
+    }
+
+}

--- a/src/test/java/org/mal_lang/icslang/test/IcsDataTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/IcsDataTest.java
@@ -1,0 +1,57 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class IcsDataTest extends IcsLangTest {
+    private static class IcsDataTestModel {
+        public final IcsData icsData = new IcsData("icsData");
+        public final IcsApplication destApp = new IcsApplication("destApp");
+
+        public IcsDataTestModel() {
+            icsData.addDataDestApp(destApp);
+        }
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+  }
+
+
+    @Test
+    public void testIcsDataWrite() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsDataTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsData.write);
+        attacker.attack();
+
+        model.destApp.manipulationOfView.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsDataDelete() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsDataTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsData.delete);
+        attacker.attack();
+
+        model.destApp.lossOfView.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsDataDeny() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsDataTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsData.deny);
+        attacker.attack();
+
+        model.destApp.lossOfView.assertCompromisedInstantaneously();
+    }
+
+}

--- a/src/test/java/org/mal_lang/icslang/test/IcsLangTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/IcsLangTest.java
@@ -1,0 +1,40 @@
+package org.mal_lang.icslang.test;
+
+import core.Asset;
+import core.AttackStep;
+import core.Defense;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IcsLangTest {
+    public static void printTestName(String name) {
+        java.lang.System.out.println("### " + name);
+    }
+
+    public static boolean isReached(AttackStep attackStep) {
+        return attackStep.ttc < Double.MAX_VALUE;
+    }
+
+    private static boolean isNotReached(AttackStep attackStep) {
+        return attackStep.ttc == Double.MAX_VALUE;
+    }
+
+    public static void assertReached(AttackStep attackStep) {
+        assertTrue(
+                isReached(attackStep),
+                String.format("Attack step %s was not reached", attackStep.fullName()));
+    }
+
+    public static void assertNotReached(AttackStep attackStep) {
+        assertTrue(
+                isNotReached(attackStep),
+                String.format("Attack step %s was reached", attackStep.fullName()));
+    }
+
+    @AfterEach
+    public void deleteModel() {
+        Asset.allAssets.clear();
+        AttackStep.allAttackSteps.clear();
+        Defense.allDefenses.clear();
+    }
+}

--- a/src/test/java/org/mal_lang/icslang/test/IcsSystemTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/IcsSystemTest.java
@@ -1,0 +1,404 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class IcsSystemTest extends IcsLangTest {
+    private static class IcsSystemSubsystemsTestModel {
+        public final IcsSystem parentIcsSystem = new
+            IcsSystem("parentIcsSystem",
+                    false, false, true, false, false, false, true);
+        public final IcsSystem criticalIcsSubsystem = new
+            IcsSystem("criticalIcsSubsystem");
+        public final IcsSystem redundantIcsSubsystem1 = new
+            IcsSystem("redundantIcsSubsystem1");
+        public final IcsSystem redundantIcsSubsystem2 = new
+            IcsSystem("redundantIcsSubsystem2");
+
+        public IcsSystemSubsystemsTestModel() {
+            parentIcsSystem.addCriticalSubsystems(criticalIcsSubsystem);
+            parentIcsSystem.addRedundantSubsystems(redundantIcsSubsystem1);
+            parentIcsSystem.addRedundantSubsystems(redundantIcsSubsystem2);
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    private static class IcsSystemDisabledRedundantSubsystemTestModel {
+        public final IcsSystem parentIcsSystem = new
+            IcsSystem("parentIcsSystem");
+        public final IcsSystem redundantIcsSubsystem = new
+            IcsSystem("redundantIcsSubsystem");
+        public final IcsSystem disabledRedundantIcsSubsystem = new
+            IcsSystem("disabledRedundantIcsSubsystem",
+                    false, false, false, false, false, false, false);
+
+        public IcsSystemDisabledRedundantSubsystemTestModel() {
+            parentIcsSystem.addRedundantSubsystems(redundantIcsSubsystem);
+            parentIcsSystem.addRedundantSubsystems(disabledRedundantIcsSubsystem);
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    private static class IcsSystemTestModel {
+        public final IcsSystem icsSystem = new IcsSystem("icsSystem");
+
+        public IcsSystemTestModel() {
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    // Impact Attack Steps Tests
+
+    /* TODO: Add tests for the non-deterministic impact attack steps on Loss
+     * of Control and View.
+     */
+
+    @Test
+    public void testIcsSystemImpactManipulationOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsSystem.manipulationOfControl);
+        attacker.attack();
+
+        /* Verify that no safety mechanisms are operating as the IcsSystem is
+         * not connected to an SIS.
+         */
+        model.icsSystem.safetyMechanismsOffline.assertCompromisedInstantaneously();
+
+        // Verify that all of the impact attack steps trigger
+        model.icsSystem.unsafeState.assertCompromisedInstantaneously();
+        model.icsSystem.shutdown.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfAvailability.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfProductivityAndRevenue.assertCompromisedInstantaneously();
+        model.icsSystem.damageToProperty.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemImpactManipulationOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsSystem.manipulationOfView);
+        attacker.attack();
+
+        /* Verify that no safety mechanisms are operating as the IcsSystem is
+         * not connected to an SIS.
+         */
+        model.icsSystem.safetyMechanismsOffline.assertCompromisedInstantaneously();
+
+        // Verify that all of the impact attack steps trigger
+        model.icsSystem.unsafeState.assertCompromisedInstantaneously();
+        model.icsSystem.shutdown.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfAvailability.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfProductivityAndRevenue.assertCompromisedInstantaneously();
+        model.icsSystem.damageToProperty.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemImpactDamageToProperty() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsSystem.damageToProperty);
+        attacker.attack();
+
+        // Verify that all of the impact attack steps trigger
+        model.icsSystem.shutdown.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfAvailability.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfProductivityAndRevenue.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemImpactShutdown() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsSystem.shutdown);
+        attacker.attack();
+
+        // Verify that all of the impact attack steps trigger
+        model.icsSystem.lossOfAvailability.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfProductivityAndRevenue.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemImpactLossOfAvailability() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsSystem.lossOfAvailability);
+        attacker.attack();
+
+        // Verify that all of the impact attack steps trigger
+        model.icsSystem.lossOfProductivityAndRevenue.assertCompromisedInstantaneously();
+    }
+
+    // Critical Subsystems Tests
+
+    @Test
+    public void testIcsSystemCriticalSubsystemLossOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.criticalIcsSubsystem.lossOfControl);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemCriticalSubsystemLossOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.criticalIcsSubsystem.lossOfView);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfView.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemCriticalSubsystemLossOfAvailability() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.criticalIcsSubsystem.lossOfAvailability);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfAvailability.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemCriticalSubsystemManipulationOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.criticalIcsSubsystem.manipulationOfControl);
+        attacker.attack();
+
+        model.parentIcsSystem.manipulationOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemCriticalSubsystemManipulationOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.criticalIcsSubsystem.manipulationOfView);
+        attacker.attack();
+
+        model.parentIcsSystem.manipulationOfView.assertCompromisedInstantaneously();
+    }
+
+    // Redundant Subsystems Test
+
+    @Test
+    public void testIcsSystemRedundantSubsystemSingleChildCompromisedLossOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.lossOfControl);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfControl.assertUncompromised();
+    }
+
+    @Test
+    public void testIcsSystemRedundantSubsystemSingleChildCompromisedLossOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.lossOfView);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfView.assertUncompromised();
+    }
+
+    @Test
+    public void testIcsSystemRedundantSubsystemSingleChildCompromisedLossOfAvailability() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.lossOfAvailability);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfAvailability.assertUncompromised();
+        model.redundantIcsSubsystem2.lossOfAvailability.assertUncompromised();
+    }
+
+    @Test
+    public void testIcsSystemRedundantSubsystemSingleChildCompromisedManipulationOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.manipulationOfControl);
+        attacker.attack();
+
+        model.parentIcsSystem.manipulationOfControl.assertUncompromised();
+    }
+
+    @Test
+    public void testIcsSystemRedundantSubsystemSingleChildCompromisedManipulationOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.manipulationOfView);
+        attacker.attack();
+
+        model.parentIcsSystem.manipulationOfView.assertUncompromised();
+    }
+
+    @Test
+    public void testIcsSystemRedundantSubsystemsBothChildrenCompromisedLossOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.lossOfControl);
+        model.addAttacker(attacker,model.redundantIcsSubsystem2.lossOfControl);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemRedundantSubsystemsBothChildrenCompromisedLossOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.lossOfView);
+        model.addAttacker(attacker,model.redundantIcsSubsystem2.lossOfView);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfView.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemRedundantSubsystemsBothChildrenCompromisedLossOfAvailability() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.lossOfAvailability);
+        model.addAttacker(attacker,model.redundantIcsSubsystem2.lossOfAvailability);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfAvailability.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemRedundantSubsystemsBothChildrenCompromisedManipulationOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.manipulationOfControl);
+        model.addAttacker(attacker,model.redundantIcsSubsystem2.manipulationOfControl);
+        attacker.attack();
+
+        model.parentIcsSystem.manipulationOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemRedundantSubsystemsBothChildrenCompromisedManipulationOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemSubsystemsTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem1.manipulationOfView);
+        model.addAttacker(attacker,model.redundantIcsSubsystem2.manipulationOfView);
+        attacker.attack();
+
+        model.parentIcsSystem.manipulationOfView.assertCompromisedInstantaneously();
+    }
+
+    // Redundant Subsystems With One Child Disabled Test
+
+    @Test
+    public void testIcsSystemRedundantDisabledSubsystemLossOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemDisabledRedundantSubsystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem.lossOfControl);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemRedundantDisabledSubsystemLossOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemDisabledRedundantSubsystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem.lossOfView);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfView.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemRedundantDisabledSubsystemLossOfAvailability() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemDisabledRedundantSubsystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem.lossOfAvailability);
+        attacker.attack();
+
+        model.parentIcsSystem.lossOfAvailability.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemRedundantDisabledSubsystemManipulationOfControl() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemDisabledRedundantSubsystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem.manipulationOfControl);
+        attacker.attack();
+
+        model.parentIcsSystem.manipulationOfControl.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testIcsSystemRedundantDisabledSubsystemManipulationOfView() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new IcsSystemDisabledRedundantSubsystemTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantIcsSubsystem.manipulationOfView);
+        attacker.attack();
+
+        model.parentIcsSystem.manipulationOfView.assertCompromisedInstantaneously();
+    }
+
+}

--- a/src/test/java/org/mal_lang/icslang/test/SISTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/SISTest.java
@@ -1,0 +1,82 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class SISTest extends IcsLangTest {
+    private static class SISTestModel {
+        public final SIS sis = new SIS("sis");
+        public final SIS disabledSis = new SIS("disabledSis",
+                false, false, false, false, false, false, false);
+        public final SIS redundantSISSubsystem = new
+            SIS("redundantSISSubsystem");
+        public final SIS redundantSISSubsystemDisabled = new
+            SIS("redundantSISSubsystemDisabled",
+                false, false, false, false, false, false, false);
+
+        public final IcsSystem icsSystem = new IcsSystem("icsSystem");
+        public final IcsSystem icsSystem2 = new IcsSystem("icsSystem2");
+
+        public SISTestModel() {
+            sis.addSafeguardedSystem(icsSystem);
+            sis.addRedundantSubsystems(redundantSISSubsystem);
+            sis.addRedundantSubsystems(redundantSISSubsystemDisabled);
+            disabledSis.addSafeguardedSystem(icsSystem2);
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    @Test
+    public void testSISPreventDamageToSystem() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SISTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsSystem.manipulationOfControl);
+        attacker.attack();
+
+        model.icsSystem.damageToProperty.assertUncompromised();
+    }
+
+    @Test
+    public void testSISShutdown() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SISTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.sis.shutdown);
+        attacker.attack();
+
+        model.icsSystem.lossOfSafety.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testSISDisabled() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SISTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.icsSystem2.manipulationOfControl);
+        attacker.attack();
+
+        model.icsSystem2.damageToProperty.assertCompromisedInstantaneously();
+        model.icsSystem2.safetyMechanismsOffline.assertCompromisedInstantaneously();
+        model.icsSystem2.lossOfSafety.assertUncompromised();
+    }
+
+    @Test
+    public void testSISRedundantSubsystemDisabled() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SISTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.redundantSISSubsystem.shutdown);
+        attacker.attack();
+
+        model.sis.shutdown.assertCompromisedInstantaneously();
+    }
+}

--- a/src/test/java/org/mal_lang/icslang/test/SensorTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/SensorTest.java
@@ -1,0 +1,41 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class SensorTest extends IcsLangTest {
+    private static class SensorTestModel {
+        public final Sensor sensor = new Sensor("sensor");
+        public final Signal signal = new Signal("signal");
+        public final IcsData icsData = new IcsData("icsData");
+        public final IcsSystem icsSystem = new IcsSystem("icsSystem");
+
+        public SensorTestModel() {
+            sensor.addSignal(signal);
+            sensor.addData(icsData);
+            sensor.addSystem(icsSystem);
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    @Test
+    public void testSensorPhysicalAccess() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SensorTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.sensor.physicalAccess);
+        attacker.attack();
+
+        model.signal.manipulateSignal.assertCompromisedInstantaneously();
+        model.signal.blockSignal.assertCompromisedInstantaneously();
+        model.icsData.attemptWrite.assertCompromisedInstantaneously();
+        model.icsData.attemptDeny.assertCompromisedInstantaneously();
+        model.icsSystem.lossOfView.assertCompromisedInstantaneously();
+        model.icsSystem.manipulationOfView.assertCompromisedInstantaneously();
+    }
+}

--- a/src/test/java/org/mal_lang/icslang/test/SignalTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/SignalTest.java
@@ -1,0 +1,109 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class SignalTest extends IcsLangTest {
+    private static class SignalTestModel {
+        public final Signal signal = new Signal("signal");
+        public final Data data = new Data("data");
+        public final Data encSignal = new Data("encSignal");
+        public final Signal nonExistentSignal = new Signal("nonExistentSignal", false, true);
+        public final Credentials signalCreds = new Credentials("signalCreds");
+        public final IcsApplication destApp = new IcsApplication("destApp");
+
+        public SignalTestModel() {
+            signal.addContainedData(data);
+            encSignal.addEncryptCreds(signalCreds);
+            signal.addSignalDestApp(destApp);
+        }
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+  }
+
+    @Test
+    public void testDataInSignal() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SignalTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.signal.attemptAccess);
+        attacker.attack();
+
+        model.signal.access.assertCompromisedInstantaneously();
+        model.signal.readContainedInformationAndData.assertCompromisedInstantaneously();
+        model.data.access.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testSignalAndDataNoAccess() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SignalTestModel();
+
+        var attacker = new Attacker();
+        attacker.attack();
+
+        model.signal.access.assertUncompromised();
+        model.signal.read.assertUncompromised();
+        model.signal.write.assertUncompromised();
+        model.signal.delete.assertUncompromised();
+
+        model.data.access.assertUncompromised();
+        model.data.read.assertUncompromised();
+        model.data.write.assertUncompromised();
+        model.data.delete.assertUncompromised();
+
+        model.encSignal.access.assertUncompromised();
+        model.encSignal.read.assertUncompromised();
+        model.encSignal.write.assertUncompromised();
+        model.encSignal.delete.assertUncompromised();
+
+        model.nonExistentSignal.access.assertUncompromised();
+        model.nonExistentSignal.read.assertUncompromised();
+        model.nonExistentSignal.write.assertUncompromised();
+        model.nonExistentSignal.delete.assertUncompromised();
+    }
+
+    @Test
+    public void testDecryptSignalUncompromisedCredentials() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SignalTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.encSignal.attemptAccess);
+        attacker.attack();
+
+        model.encSignal.access.assertUncompromised();
+        model.encSignal.read.assertUncompromised();
+        model.encSignal.write.assertUncompromised();
+        model.encSignal.delete.assertUncompromised();
+    }
+
+    @Test
+    public void testManipulateSignal() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SignalTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.signal.manipulateSignal);
+        attacker.attack();
+
+        model.destApp.manipulationOfView.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testBlockSignal() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SignalTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.signal.blockSignal);
+        attacker.attack();
+
+        model.destApp.lossOfView.assertCompromisedInstantaneously();
+    }
+
+
+}

--- a/src/test/java/org/mal_lang/icslang/test/SynchronizationModuleTest.java
+++ b/src/test/java/org/mal_lang/icslang/test/SynchronizationModuleTest.java
@@ -1,0 +1,75 @@
+package org.mal_lang.icslang.test;
+
+import core.Attacker;
+import core.AttackStep;
+import org.junit.jupiter.api.Test;
+
+public class SynchronizationModuleTest extends IcsLangTest {
+    private static class SynchronizationModuleTestModel {
+        public final SynchronizationModule synchronizationModule = new
+            SynchronizationModule("synchronizationModule");
+        public final IcsApplication icsApplication = new
+            IcsApplication("icsApplication");
+
+        public SynchronizationModuleTestModel() {
+            synchronizationModule.addSynchronizedApp(icsApplication);
+        }
+
+        public void addAttacker(Attacker attacker, AttackStep attackpoint) {
+            attacker.addAttackPoint(attackpoint);
+        }
+    }
+
+    @Test
+    public void testSynchronizationModuleCompromise() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SynchronizationModuleTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.synchronizationModule.compromise);
+        attacker.attack();
+
+        model.synchronizationModule.manipulateClockFrequency.assertCompromisedInstantaneously();
+        model.synchronizationModule.manipulateTime.assertCompromisedInstantaneously();
+        model.synchronizationModule.stopClock.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testSynchronizationModuleManipulateClockFrequency() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SynchronizationModuleTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.synchronizationModule.manipulateClockFrequency);
+        attacker.attack();
+
+        model.icsApplication.manipulationOfControl.assertCompromisedInstantaneously();
+        model.icsApplication.manipulationOfView.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testSynchronizationModuleManipulateTime() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SynchronizationModuleTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.synchronizationModule.manipulateTime);
+        attacker.attack();
+
+        model.icsApplication.manipulationOfControl.assertCompromisedInstantaneously();
+        model.icsApplication.manipulationOfView.assertCompromisedInstantaneously();
+    }
+
+    @Test
+    public void testSynchronizationModuleStopClock() {
+        printTestName(Thread.currentThread().getStackTrace()[1].getMethodName());
+        var model = new SynchronizationModuleTestModel();
+
+        var attacker = new Attacker();
+        model.addAttacker(attacker,model.synchronizationModule.stopClock);
+        attacker.attack();
+
+        model.icsApplication.lossOfControl.assertCompromisedInstantaneously();
+        model.icsApplication.lossOfView.assertCompromisedInstantaneously();
+    }
+}


### PR DESCRIPTION
Introduce **IcsData**/**IcsControlData** analogous to how **signals** are used. Separate information and control flows of **data**/**signals** so that the appropriate impact attack steps are triggered.

This is another broad change to the icsLang code base.

There are two major components included, both related to **data**/**signals** in icsLang.

1. Introduced **IcsData** to mirror the behaviour of the **Signal** asset. The **Signal** asset should be used when the medium is unknown or otherwise considered irrelevant and **IcsData** should be used when the medium is pertinent to the modelling process. The two are still not perfectly aligned, but most of their steps are analogous.
2. Introduced **IcsControlData** and **ControlSignal** to separate the control flow from the information flow. This is needed to properly trigger the impact attack steps. **Manipulation**/**Loss** of **View** occur when the information flow is disrupted and it propagates upward, to the higher level components that would receive the information. **Manipulation**/**Loss** of **Control** occur when the control flow is disrupted and it propagates downward, to the lower components that would receive the commands. **Signal** and **Data** are seen as the means to spread the disruptions. There are three exceptions, **icsSystems**, **Sensors**, and **Actuators** all propagate their disruptions to their parent **icsSystem**. This is done to reflect the physical dimension of the disruptions, as opposed to the logical dimension represented in the **IcsApplications** and **Data**/**Signal**.